### PR TITLE
add catppuccin themes, standardize all themes to powerline format, fix bugs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.tmuxtheme]
+indent_style = space
+indent_size = 2
+
+[*.tmux]
+indent_style = tab
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing a New Theme
+
+Thanks for wanting to add a theme! Here's everything you need.
+
+## Theme file format
+
+All themes live in `themes/` as `<theme-name>.tmuxtheme` files. Use the powerline format below — it produces clean, consistent status bars across all terminal emulators.
+
+### Template
+
+Copy this and substitute your palette colors (replace every `#xxxxxx` value):
+
+```tmux
+# <Theme Name>
+# Palette: <link to upstream palette>
+# <key color role comments, e.g.: bg=#1e1e2e accent=#89b4fa text=#cdd6f4>
+
+set -g mode-style "fg=<ACCENT>,bg=<SURFACE>"
+
+set -g message-style "fg=<ACCENT>,bg=<SURFACE>"
+set -g message-command-style "fg=<ACCENT>,bg=<SURFACE>"
+
+set -g pane-border-style "fg=<SURFACE>"
+set -g pane-active-border-style "fg=<ACCENT>"
+
+set -g status "on"
+set -g status-justify "left"
+
+set -g status-style "fg=<ACCENT>,bg=<BG>"
+
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+set -g status-left-style NONE
+set -g status-right-style NONE
+
+set -g status-left "#[fg=<BG>,bg=<ACCENT>,bold] #S #[fg=<ACCENT>,bg=<BG>,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=<BG>,bg=<BG>,nobold,nounderscore,noitalics]#[fg=<ACCENT>,bg=<BG>] #{prefix_highlight} #[fg=<SURFACE>,bg=<BG>,nobold,nounderscore,noitalics]#[fg=<ACCENT>,bg=<SURFACE>] %Y-%m-%d  %I:%M %p #[fg=<ACCENT>,bg=<SURFACE>,nobold,nounderscore,noitalics]#[fg=<BG>,bg=<ACCENT>,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=<BG>,bg=<BG>,nobold,nounderscore,noitalics]#[fg=<ACCENT>,bg=<BG>] #{prefix_highlight} #[fg=<SURFACE>,bg=<BG>,nobold,nounderscore,noitalics]#[fg=<ACCENT>,bg=<SURFACE>] %Y-%m-%d  %H:%M #[fg=<ACCENT>,bg=<SURFACE>,nobold,nounderscore,noitalics]#[fg=<BG>,bg=<ACCENT>,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=<TEXT>,bg=<BG>"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=<TEXT>,bg=<BG>"
+setw -g window-status-format "#[fg=<BG>,bg=<BG>,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=<BG>,bg=<BG>,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=<BG>,bg=<SURFACE>,nobold,nounderscore,noitalics]#[fg=<ACCENT>,bg=<SURFACE>,bold] #I  #W #F #[fg=<SURFACE>,bg=<BG>,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=<HIGHLIGHT>]#[bg=<BG>]#[fg=<BG>]#[bg=<HIGHLIGHT>]"
+set -g @prefix_highlight_output_suffix ""
+```
+
+### Color roles
+
+| Placeholder | Role | Example (Catppuccin Mocha) |
+|---|---|---|
+| `<BG>` | Darkest background (status bar) | `#11111b` (crust) |
+| `<SURFACE>` | Elevated surface (active window bg) | `#45475a` (surface1) |
+| `<ACCENT>` | Primary accent color | `#89b4fa` (blue) |
+| `<TEXT>` | Inactive window / subdued text | `#cdd6f4` (text) |
+| `<HIGHLIGHT>` | Prefix highlight accent (often yellow/orange) | `#f9e2af` (yellow) |
+
+For **light themes**, swap `<BG>` to the lightest background and `<TEXT>` to a dark foreground color — see `catppuccin-latte.tmuxtheme` for a reference.
+
+## Checklist
+
+- [ ] File is `themes/<theme-name>.tmuxtheme` (lowercase, hyphen-separated)
+- [ ] All colors use `#rrggbb` hex format (no terminal color names or `colourN`)
+- [ ] A comment at the top links to the upstream palette
+- [ ] The 12h/24h clock `if-shell` block is included
+- [ ] `@prefix_highlight_output_prefix/suffix` are set
+- [ ] Theme is listed in `README.md` under the correct section
+- [ ] ShellCheck passes: `shellcheck themes/<theme-name>.tmuxtheme` (or run the CI)
+
+## Naming conventions
+
+- Single palette, dark variant: `<palette>-dark` (e.g. `gruvbox-dark`)
+- Single palette, light variant: `<palette>-light` (e.g. `solarized-light`)
+- Palette with named flavors: `<palette>-<flavor>` (e.g. `catppuccin-mocha`)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 ![Shellcheck](https://github.com/jeircul/tmux-themes/actions/workflows/shellcheck.yml/badge.svg)
 
-# Tmux themes
+# tmux-themes
+
+A collection of clean, powerline-style tmux status bar themes. All themes use consistent `#rrggbb` hex colors and the same powerline segment format so they look sharp across terminals.
 
 ## 📦 Installation via [TPM](https://github.com/tmux-plugins/tpm) (recommended)
 
-1.  Add plugin to the list of TPM plugins in `.tmux.conf`:
+1. Add plugin to the list of TPM plugins in `.tmux.conf`:
 
-    ``` tmux
-    set -g @plugin 'jeircul/tmux-themes'
-    ```
-2.  Use <kbd>prefix</kbd>–<kbd>I</kbd> to install `tmux-themes`.
-3.  When you want to update `tmux-themes` use <kbd>prefix</kbd>–<kbd>U</kbd>.
+   ```tmux
+   set -g @plugin 'jeircul/tmux-themes'
+   ```
+
+2. Use <kbd>prefix</kbd>–<kbd>I</kbd> to install `tmux-themes`.
+3. When you want to update `tmux-themes` use <kbd>prefix</kbd>–<kbd>U</kbd>.
 
 <details>
 <summary>📦 Manual Installation</summary>
@@ -18,32 +21,105 @@
 1. Clone the repo:
 
    ```sh
-   git clone https://github.com/jeircul/tmux-themes ~/.config/tmux/plugins/
+   git clone https://github.com/jeircul/tmux-themes ~/.config/tmux/plugins/tmux-themes
    ```
+
 2. Add this line to the bottom of `.tmux.conf`:
 
    ```tmux
-   run-shell ~/.config/tmux/plugins/tmux-themes/themes.tmux
+   run-shell ~/.config/tmux/plugins/tmux-themes/theme.tmux
    ```
-3. Use <kbd>prefix</kbd>–<kbd>R</kbd> to Reload TMUX environment
+
+3. Use <kbd>prefix</kbd>–<kbd>R</kbd> to reload the TMUX environment.
 </details>
 
 ## 🚀 Usage
 
-Choose theme by adding one of the options to `.tmux.conf`:
+Add one line to `.tmux.conf` to choose your theme:
 
-### Default
-- `set -g @tmux-statusline-theme 'tokyonight-night'`
+```tmux
+set -g @tmux-statusline-theme 'catppuccin-mocha'
+```
 
-### Other themes 
-- `set -g @tmux-statusline-theme 'tokyonight-storm'`
-- `set -g @tmux-statusline-theme 'tokyonight-moon'`
-- `set -g @tmux-statusline-theme 'tokyonight-day'`
-- `set -g @tmux-statusline-theme 'ayu-light'`
-- `set -g @tmux-statusline-theme 'gruvbox-dark'`
-- `set -g @tmux-statusline-theme 'solarized-light'`
-- `set -g @tmux-statusline-theme 'solarized-dark'`
-- `set -g @tmux-statusline-theme 'two-firewatch-dark'`
+If no theme is set, `tokyonight-night` is used as the default.
+
+## 🎨 Available Themes
+
+### Catppuccin
+
+| Theme | Flavor | Style |
+|---|---|---|
+| `catppuccin-mocha` | Mocha | Dark |
+| `catppuccin-macchiato` | Macchiato | Dark |
+| `catppuccin-frappe` | Frappé | Dark |
+| `catppuccin-latte` | Latte | Light |
+
+```tmux
+set -g @tmux-statusline-theme 'catppuccin-mocha'
+set -g @tmux-statusline-theme 'catppuccin-macchiato'
+set -g @tmux-statusline-theme 'catppuccin-frappe'
+set -g @tmux-statusline-theme 'catppuccin-latte'
+```
+
+### Tokyonight
+
+| Theme | Style |
+|---|---|
+| `tokyonight-night` | Dark (default) |
+| `tokyonight-storm` | Dark |
+| `tokyonight-moon` | Dark |
+| `tokyonight-day` | Light |
+
+```tmux
+set -g @tmux-statusline-theme 'tokyonight-night'
+set -g @tmux-statusline-theme 'tokyonight-storm'
+set -g @tmux-statusline-theme 'tokyonight-moon'
+set -g @tmux-statusline-theme 'tokyonight-day'
+```
+
+### Gruvbox
+
+| Theme | Style |
+|---|---|
+| `gruvbox-dark` | Dark |
+| `gruvbox-light-hard` | Light |
+
+```tmux
+set -g @tmux-statusline-theme 'gruvbox-dark'
+set -g @tmux-statusline-theme 'gruvbox-light-hard'
+```
+
+### Solarized
+
+| Theme | Style |
+|---|---|
+| `solarized-dark` | Dark |
+| `solarized-light` | Light |
+
+```tmux
+set -g @tmux-statusline-theme 'solarized-dark'
+set -g @tmux-statusline-theme 'solarized-light'
+```
+
+### Other
+
+| Theme | Style |
+|---|---|
+| `ayu-light` | Light |
+| `two-firewatch-light` | Light |
+
+```tmux
+set -g @tmux-statusline-theme 'ayu-light'
+set -g @tmux-statusline-theme 'two-firewatch-light'
+```
+
+## 🔌 Plugin Support
+
+Themes include built-in support for [tmux-prefix-highlight](https://github.com/tmux-plugins/tmux-prefix-highlight). The highlight colors are tuned per-theme.
+
+## 🤝 Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add a new theme.
 
 ## ⚖ License
 

--- a/theme.tmux
+++ b/theme.tmux
@@ -2,7 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-theme_option="@tmux-themes"
+theme_option="@tmux-statusline-theme"
 default_theme="tokyonight-night"
 
 get_tmux_option() {
@@ -18,9 +18,17 @@ get_tmux_option() {
 }
 
 main() {
-	local theme
+	local theme theme_file
 	theme="$(get_tmux_option "$theme_option" "$default_theme")"
-	tmux source-file "$CURRENT_DIR/themes/${theme}.tmuxtheme"
+	theme_file="$CURRENT_DIR/themes/${theme}.tmuxtheme"
+
+	if [ ! -f "$theme_file" ]; then
+		tmux display-message "tmux-themes: unknown theme '${theme}'. Check available themes in ~/.tmux.conf."
+		# Fall back to default so tmux stays functional
+		theme_file="$CURRENT_DIR/themes/${default_theme}.tmuxtheme"
+	fi
+
+	tmux source-file "$theme_file"
 }
 
 main

--- a/themes/ayu-light.tmuxtheme
+++ b/themes/ayu-light.tmuxtheme
@@ -1,32 +1,38 @@
-# Tmux status line for `ayu-light` color scheme.
+# Ayu Light
+# Palette: https://github.com/ayu-theme/ayu-colors
+# bg=#fafafa panel=#f3f4f5 border=#e7e8e9 accent=#ff9940 blue=#36a3d9 fg=#5c6166
 
-# Status bar colors.
-set-window-option -g status-style fg=brightyellow,bg=brightwhite,none
+set -g mode-style "fg=#36a3d9,bg=#e7e8e9"
 
-# Window list colors.
-set-window-option -g window-status-style fg=white,bg=green,none
-set-window-option -g window-status-current-style fg=white,bg=brightgreen,bold
-set-window-option -g window-status-activity-style fg=white,bg=yellow,none
+set -g message-style "fg=#5c6166,bg=#e7e8e9"
+set -g message-command-style "fg=#5c6166,bg=#e7e8e9"
 
-# Pane divider colors.
-set-option -g pane-border-style fg=brightyellow,bg=default
-set-option -g pane-active-border-style fg=yellow,bg=default
+set -g pane-border-style "fg=#e7e8e9"
+set -g pane-active-border-style "fg=#ff9940"
 
-# Command-line messages colors.
-set-option message-style fg=brightyellow,bg=brightwhite
+set -g status "on"
+set -g status-justify "left"
 
-# Set left and right sections.
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=white,bg=green] #S "
-set-option -g status-right "#[fg=white,bg=green] #(whoami)@#H "
+set -g status-style "fg=#5c6166,bg=#f3f4f5"
 
-# Set format of items in window list.
-setw -g window-status-format " #I:#W#F "
-setw -g window-status-current-format " #I:#W#F "
+set -g status-left-length "100"
+set -g status-right-length "100"
 
-# Set alignment of windows list.
-set-option -g status-justify centre
+set -g status-left-style NONE
+set -g status-right-style NONE
 
-# Identify activity in non-current windows.
-set-window-option -g monitor-activity on
-set-option -g visual-activity on
+set -g status-left "#[fg=#f3f4f5,bg=#ff9940,bold] #S #[fg=#ff9940,bg=#f3f4f5,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#f3f4f5,bg=#f3f4f5,nobold,nounderscore,noitalics]#[fg=#5c6166,bg=#f3f4f5] #{prefix_highlight} #[fg=#e7e8e9,bg=#f3f4f5,nobold,nounderscore,noitalics]#[fg=#5c6166,bg=#e7e8e9] %Y-%m-%d  %I:%M %p #[fg=#ff9940,bg=#e7e8e9,nobold,nounderscore,noitalics]#[fg=#f3f4f5,bg=#ff9940,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#f3f4f5,bg=#f3f4f5,nobold,nounderscore,noitalics]#[fg=#5c6166,bg=#f3f4f5] #{prefix_highlight} #[fg=#e7e8e9,bg=#f3f4f5,nobold,nounderscore,noitalics]#[fg=#5c6166,bg=#e7e8e9] %Y-%m-%d  %H:%M #[fg=#ff9940,bg=#e7e8e9,nobold,nounderscore,noitalics]#[fg=#f3f4f5,bg=#ff9940,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#8a9099,bg=#f3f4f5"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#8a9099,bg=#f3f4f5"
+setw -g window-status-format "#[fg=#f3f4f5,bg=#f3f4f5,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#f3f4f5,bg=#f3f4f5,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#f3f4f5,bg=#e7e8e9,nobold,nounderscore,noitalics]#[fg=#36a3d9,bg=#e7e8e9,bold] #I  #W #F #[fg=#e7e8e9,bg=#f3f4f5,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#ff9940]#[bg=#f3f4f5]#[fg=#f3f4f5]#[bg=#ff9940]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/catppuccin-frappe.tmuxtheme
+++ b/themes/catppuccin-frappe.tmuxtheme
@@ -1,0 +1,38 @@
+# Catppuccin Frappe
+# Palette: https://github.com/catppuccin/catppuccin#-palette
+# base=#303446 crust=#232634 surface1=#51576d blue=#8caaee text=#c6d0f5 yellow=#e5c890
+
+set -g mode-style "fg=#8caaee,bg=#51576d"
+
+set -g message-style "fg=#8caaee,bg=#51576d"
+set -g message-command-style "fg=#8caaee,bg=#51576d"
+
+set -g pane-border-style "fg=#51576d"
+set -g pane-active-border-style "fg=#8caaee"
+
+set -g status "on"
+set -g status-justify "left"
+
+set -g status-style "fg=#8caaee,bg=#232634"
+
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+set -g status-left-style NONE
+set -g status-right-style NONE
+
+set -g status-left "#[fg=#232634,bg=#8caaee,bold] #S #[fg=#8caaee,bg=#232634,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#232634,bg=#232634,nobold,nounderscore,noitalics]#[fg=#8caaee,bg=#232634] #{prefix_highlight} #[fg=#51576d,bg=#232634,nobold,nounderscore,noitalics]#[fg=#8caaee,bg=#51576d] %Y-%m-%d  %I:%M %p #[fg=#8caaee,bg=#51576d,nobold,nounderscore,noitalics]#[fg=#232634,bg=#8caaee,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#232634,bg=#232634,nobold,nounderscore,noitalics]#[fg=#8caaee,bg=#232634] #{prefix_highlight} #[fg=#51576d,bg=#232634,nobold,nounderscore,noitalics]#[fg=#8caaee,bg=#51576d] %Y-%m-%d  %H:%M #[fg=#8caaee,bg=#51576d,nobold,nounderscore,noitalics]#[fg=#232634,bg=#8caaee,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#c6d0f5,bg=#232634"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#c6d0f5,bg=#232634"
+setw -g window-status-format "#[fg=#232634,bg=#232634,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#232634,bg=#232634,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#232634,bg=#51576d,nobold,nounderscore,noitalics]#[fg=#8caaee,bg=#51576d,bold] #I  #W #F #[fg=#51576d,bg=#232634,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#e5c890]#[bg=#232634]#[fg=#232634]#[bg=#e5c890]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/catppuccin-latte.tmuxtheme
+++ b/themes/catppuccin-latte.tmuxtheme
@@ -1,0 +1,38 @@
+# Catppuccin Latte (light)
+# Palette: https://github.com/catppuccin/catppuccin#-palette
+# base=#eff1f5 mantle=#e6e9ef surface1=#bcc0cc blue=#1e66f5 text=#4c4f69 yellow=#df8e1d
+
+set -g mode-style "fg=#1e66f5,bg=#bcc0cc"
+
+set -g message-style "fg=#1e66f5,bg=#bcc0cc"
+set -g message-command-style "fg=#1e66f5,bg=#bcc0cc"
+
+set -g pane-border-style "fg=#bcc0cc"
+set -g pane-active-border-style "fg=#1e66f5"
+
+set -g status "on"
+set -g status-justify "left"
+
+set -g status-style "fg=#1e66f5,bg=#e6e9ef"
+
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+set -g status-left-style NONE
+set -g status-right-style NONE
+
+set -g status-left "#[fg=#e6e9ef,bg=#1e66f5,bold] #S #[fg=#1e66f5,bg=#e6e9ef,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#e6e9ef,bg=#e6e9ef,nobold,nounderscore,noitalics]#[fg=#1e66f5,bg=#e6e9ef] #{prefix_highlight} #[fg=#bcc0cc,bg=#e6e9ef,nobold,nounderscore,noitalics]#[fg=#4c4f69,bg=#bcc0cc] %Y-%m-%d  %I:%M %p #[fg=#1e66f5,bg=#bcc0cc,nobold,nounderscore,noitalics]#[fg=#e6e9ef,bg=#1e66f5,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#e6e9ef,bg=#e6e9ef,nobold,nounderscore,noitalics]#[fg=#1e66f5,bg=#e6e9ef] #{prefix_highlight} #[fg=#bcc0cc,bg=#e6e9ef,nobold,nounderscore,noitalics]#[fg=#4c4f69,bg=#bcc0cc] %Y-%m-%d  %H:%M #[fg=#1e66f5,bg=#bcc0cc,nobold,nounderscore,noitalics]#[fg=#e6e9ef,bg=#1e66f5,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#4c4f69,bg=#e6e9ef"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#4c4f69,bg=#e6e9ef"
+setw -g window-status-format "#[fg=#e6e9ef,bg=#e6e9ef,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#e6e9ef,bg=#e6e9ef,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#e6e9ef,bg=#bcc0cc,nobold,nounderscore,noitalics]#[fg=#1e66f5,bg=#bcc0cc,bold] #I  #W #F #[fg=#bcc0cc,bg=#e6e9ef,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#df8e1d]#[bg=#e6e9ef]#[fg=#e6e9ef]#[bg=#df8e1d]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/catppuccin-macchiato.tmuxtheme
+++ b/themes/catppuccin-macchiato.tmuxtheme
@@ -1,0 +1,38 @@
+# Catppuccin Macchiato
+# Palette: https://github.com/catppuccin/catppuccin#-palette
+# base=#24273a crust=#181926 surface1=#494d64 blue=#8aadf4 text=#cad3f5 yellow=#eed49f
+
+set -g mode-style "fg=#8aadf4,bg=#494d64"
+
+set -g message-style "fg=#8aadf4,bg=#494d64"
+set -g message-command-style "fg=#8aadf4,bg=#494d64"
+
+set -g pane-border-style "fg=#494d64"
+set -g pane-active-border-style "fg=#8aadf4"
+
+set -g status "on"
+set -g status-justify "left"
+
+set -g status-style "fg=#8aadf4,bg=#181926"
+
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+set -g status-left-style NONE
+set -g status-right-style NONE
+
+set -g status-left "#[fg=#181926,bg=#8aadf4,bold] #S #[fg=#8aadf4,bg=#181926,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#181926,bg=#181926,nobold,nounderscore,noitalics]#[fg=#8aadf4,bg=#181926] #{prefix_highlight} #[fg=#494d64,bg=#181926,nobold,nounderscore,noitalics]#[fg=#8aadf4,bg=#494d64] %Y-%m-%d  %I:%M %p #[fg=#8aadf4,bg=#494d64,nobold,nounderscore,noitalics]#[fg=#181926,bg=#8aadf4,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#181926,bg=#181926,nobold,nounderscore,noitalics]#[fg=#8aadf4,bg=#181926] #{prefix_highlight} #[fg=#494d64,bg=#181926,nobold,nounderscore,noitalics]#[fg=#8aadf4,bg=#494d64] %Y-%m-%d  %H:%M #[fg=#8aadf4,bg=#494d64,nobold,nounderscore,noitalics]#[fg=#181926,bg=#8aadf4,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#cad3f5,bg=#181926"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#cad3f5,bg=#181926"
+setw -g window-status-format "#[fg=#181926,bg=#181926,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#181926,bg=#181926,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#181926,bg=#494d64,nobold,nounderscore,noitalics]#[fg=#8aadf4,bg=#494d64,bold] #I  #W #F #[fg=#494d64,bg=#181926,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#eed49f]#[bg=#181926]#[fg=#181926]#[bg=#eed49f]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/catppuccin-mocha.tmuxtheme
+++ b/themes/catppuccin-mocha.tmuxtheme
@@ -1,0 +1,38 @@
+# Catppuccin Mocha
+# Palette: https://github.com/catppuccin/catppuccin#-palette
+# base=#1e1e2e crust=#11111b surface1=#45475a blue=#89b4fa text=#cdd6f4 yellow=#f9e2af
+
+set -g mode-style "fg=#89b4fa,bg=#45475a"
+
+set -g message-style "fg=#89b4fa,bg=#45475a"
+set -g message-command-style "fg=#89b4fa,bg=#45475a"
+
+set -g pane-border-style "fg=#45475a"
+set -g pane-active-border-style "fg=#89b4fa"
+
+set -g status "on"
+set -g status-justify "left"
+
+set -g status-style "fg=#89b4fa,bg=#11111b"
+
+set -g status-left-length "100"
+set -g status-right-length "100"
+
+set -g status-left-style NONE
+set -g status-right-style NONE
+
+set -g status-left "#[fg=#11111b,bg=#89b4fa,bold] #S #[fg=#89b4fa,bg=#11111b,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#11111b,bg=#11111b,nobold,nounderscore,noitalics]#[fg=#89b4fa,bg=#11111b] #{prefix_highlight} #[fg=#45475a,bg=#11111b,nobold,nounderscore,noitalics]#[fg=#89b4fa,bg=#45475a] %Y-%m-%d  %I:%M %p #[fg=#89b4fa,bg=#45475a,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#89b4fa,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#11111b,bg=#11111b,nobold,nounderscore,noitalics]#[fg=#89b4fa,bg=#11111b] #{prefix_highlight} #[fg=#45475a,bg=#11111b,nobold,nounderscore,noitalics]#[fg=#89b4fa,bg=#45475a] %Y-%m-%d  %H:%M #[fg=#89b4fa,bg=#45475a,nobold,nounderscore,noitalics]#[fg=#11111b,bg=#89b4fa,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#cdd6f4,bg=#11111b"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#cdd6f4,bg=#11111b"
+setw -g window-status-format "#[fg=#11111b,bg=#11111b,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#11111b,bg=#11111b,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#11111b,bg=#45475a,nobold,nounderscore,noitalics]#[fg=#89b4fa,bg=#45475a,bold] #I  #W #F #[fg=#45475a,bg=#11111b,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#f9e2af]#[bg=#11111b]#[fg=#11111b]#[bg=#f9e2af]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/gruvbox-dark.tmuxtheme
+++ b/themes/gruvbox-dark.tmuxtheme
@@ -1,38 +1,38 @@
-# Tmux status line with gruvbox dark colors.
+# Gruvbox Dark
 # Palette: https://github.com/morhetz/gruvbox#palette
+# bg0=#282828 bg1=#3c3836 fg1=#ebdbb2 yellow=#d79921
 
-# Status bar colors.
-set-option -g status-fg colour223 # fg1
-set-option -g status-bg colour235 # bg0
+set -g mode-style "fg=#d79921,bg=#3c3836"
 
-# Window list colors.
-set-window-option -g window-status-style fg=colour246,bg=colour239
-set-window-option -g window-status-current-style fg=colour235,bg=colour246,bright
-set-window-option -g window-status-activity-style fg=colour250,bg=colour241
+set -g message-style "fg=#ebdbb2,bg=#3c3836"
+set -g message-command-style "fg=#ebdbb2,bg=#3c3836"
 
-# Pane divider colors.
-set-option -g pane-border-style fg=colour239 # bg2
-set-option -g pane-border-style bg=colour235 # bg0
-set-option -g pane-active-border-style fg=colour142 # brightgreen
-set-option -g pane-active-border-style bg=colour235 # bg0
+set -g pane-border-style "fg=#3c3836"
+set -g pane-active-border-style "fg=#d79921"
 
-# Command-line messages colors.
-set-option -g message-style fg=colour223 # fg1
-set-option -g message-style bg=colour235 # bg0
-set-option -g message-style bright
+set -g status "on"
+set -g status-justify "left"
 
-# Set left and right sections.
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=colour235,bg=colour246] #S "
-set-option -g status-right "#[fg=colour235,bg=colour246] #(whoami)@#H "
+set -g status-style "fg=#ebdbb2,bg=#282828"
 
-# Set format of items in window list.
-setw -g window-status-format " #I:#W#F "
-setw -g window-status-current-format " #I:#W#F "
+set -g status-left-length "100"
+set -g status-right-length "100"
 
-# Set alignment of windows list.
-set-option -g status-justify centre
+set -g status-left-style NONE
+set -g status-right-style NONE
 
-# Identify activity in non-current windows.
-set-window-option -g monitor-activity on
-set-option -g visual-activity on
+set -g status-left "#[fg=#282828,bg=#d79921,bold] #S #[fg=#d79921,bg=#282828,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#282828,bg=#282828,nobold,nounderscore,noitalics]#[fg=#ebdbb2,bg=#282828] #{prefix_highlight} #[fg=#3c3836,bg=#282828,nobold,nounderscore,noitalics]#[fg=#ebdbb2,bg=#3c3836] %Y-%m-%d  %I:%M %p #[fg=#ebdbb2,bg=#3c3836,nobold,nounderscore,noitalics]#[fg=#282828,bg=#d79921,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#282828,bg=#282828,nobold,nounderscore,noitalics]#[fg=#ebdbb2,bg=#282828] #{prefix_highlight} #[fg=#3c3836,bg=#282828,nobold,nounderscore,noitalics]#[fg=#ebdbb2,bg=#3c3836] %Y-%m-%d  %H:%M #[fg=#ebdbb2,bg=#3c3836,nobold,nounderscore,noitalics]#[fg=#282828,bg=#d79921,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#a89984,bg=#282828"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#a89984,bg=#282828"
+setw -g window-status-format "#[fg=#282828,bg=#282828,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#282828,bg=#282828,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#282828,bg=#3c3836,nobold,nounderscore,noitalics]#[fg=#ebdbb2,bg=#3c3836,bold] #I  #W #F #[fg=#3c3836,bg=#282828,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#d79921]#[bg=#282828]#[fg=#282828]#[bg=#d79921]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/gruvbox-light-hard.tmuxtheme
+++ b/themes/gruvbox-light-hard.tmuxtheme
@@ -1,38 +1,38 @@
-# Tmux status line with gruvbox light colors.
-# Palette: https://github.com/morhetz/gruvbox#light-mode-1
+# Gruvbox Light Hard
+# Palette: https://github.com/morhetz/gruvbox#palette
+# bg0_h=#f9f5d7 bg1=#ebdbb2 fg1=#3c3836 blue=#076678 yellow=#b57614
 
-# Status bar colors.
-set-option -g status-fg colour235 # fg1
-set-option -g status-bg colour230 # bg0
+set -g mode-style "fg=#076678,bg=#ebdbb2"
 
-# Window list colors.
-set-window-option -g window-status-style fg=colour230,bg=colour24
-set-window-option -g window-status-current-style fg=colour230,bg=colour136,bright
-set-window-option -g window-status-activity-style fg=colour230,bg=colour246
+set -g message-style "fg=#3c3836,bg=#ebdbb2"
+set -g message-command-style "fg=#3c3836,bg=#ebdbb2"
 
-# Pane divider colors.
-set-option -g pane-border-style fg=colour239 # bg2
-set-option -g pane-border-style bg=colour235 # bg0
-set-option -g pane-active-border-style fg=colour142 # brightgreen
-set-option -g pane-active-border-style bg=colour235 # bg0
+set -g pane-border-style "fg=#ebdbb2"
+set -g pane-active-border-style "fg=#076678"
 
-# Command-line messages colors.
-set-option -g message-style fg=colour235 # fg1
-set-option -g message-style bg=colour230 # bg0
-set-option -g message-style bright
+set -g status "on"
+set -g status-justify "left"
 
-# Set left and right sections.
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=colour15,bg=colour0] #S "
-set-option -g status-right "#[fg=colour15,bg=colour0] #(whoami)@#H "
+set -g status-style "fg=#3c3836,bg=#f9f5d7"
 
-# Set format of items in window list.
-setw -g window-status-format " #I:#W#F "
-setw -g window-status-current-format " #I:#W#F "
+set -g status-left-length "100"
+set -g status-right-length "100"
 
-# Set alignment of windows list.
-set-option -g status-justify centre
+set -g status-left-style NONE
+set -g status-right-style NONE
 
-# Identify activity in non-current windows.
-set-window-option -g monitor-activity on
-set-option -g visual-activity on
+set -g status-left "#[fg=#f9f5d7,bg=#076678,bold] #S #[fg=#076678,bg=#f9f5d7,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#f9f5d7,bg=#f9f5d7,nobold,nounderscore,noitalics]#[fg=#3c3836,bg=#f9f5d7] #{prefix_highlight} #[fg=#ebdbb2,bg=#f9f5d7,nobold,nounderscore,noitalics]#[fg=#3c3836,bg=#ebdbb2] %Y-%m-%d  %I:%M %p #[fg=#076678,bg=#ebdbb2,nobold,nounderscore,noitalics]#[fg=#f9f5d7,bg=#076678,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#f9f5d7,bg=#f9f5d7,nobold,nounderscore,noitalics]#[fg=#3c3836,bg=#f9f5d7] #{prefix_highlight} #[fg=#ebdbb2,bg=#f9f5d7,nobold,nounderscore,noitalics]#[fg=#3c3836,bg=#ebdbb2] %Y-%m-%d  %H:%M #[fg=#076678,bg=#ebdbb2,nobold,nounderscore,noitalics]#[fg=#f9f5d7,bg=#076678,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#7c6f64,bg=#f9f5d7"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#7c6f64,bg=#f9f5d7"
+setw -g window-status-format "#[fg=#f9f5d7,bg=#f9f5d7,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#f9f5d7,bg=#f9f5d7,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#f9f5d7,bg=#ebdbb2,nobold,nounderscore,noitalics]#[fg=#3c3836,bg=#ebdbb2,bold] #I  #W #F #[fg=#ebdbb2,bg=#f9f5d7,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#b57614]#[bg=#f9f5d7]#[fg=#f9f5d7]#[bg=#b57614]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/solarized-dark.tmuxtheme
+++ b/themes/solarized-dark.tmuxtheme
@@ -1,33 +1,38 @@
-# Tmux status line with solarized light colors.
-# Palette: http://ricky.thecampbells.info/solarized-quick-reference-posters/
+# Solarized Dark
+# Palette: https://ethanschoonover.com/solarized/
+# base03=#002b36 base02=#073642 base01=#586e75 base1=#93a1a1 yellow=#b58900 cyan=#2aa198
 
-# Status bar colors.
-set-window-option -g status-style fg=brightyellow,bg=brightblack,none
+set -g mode-style "fg=#2aa198,bg=#073642"
 
-# Window list colors.
-set-window-option -g window-status-style fg=white,bg=black,none
-set-window-option -g window-status-current-style fg=white,bg=brightgreen,bold
-set-window-option -g window-status-activity-style fg=white,bg=brightyellow,none
+set -g message-style "fg=#93a1a1,bg=#073642"
+set -g message-command-style "fg=#93a1a1,bg=#073642"
 
-# Pane divider colors.
-set-option -g pane-border-style fg=brightyellow,bg=default
-set-option -g pane-active-border-style fg=yellow,bg=default
+set -g pane-border-style "fg=#073642"
+set -g pane-active-border-style "fg=#2aa198"
 
-# Command-line messages colors.
-set-option message-style fg=brightyellow,bg=brightwhite
+set -g status "on"
+set -g status-justify "left"
 
-# Set left and right sections.
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=white,bg=black] #S "
-set-option -g status-right "#[fg=white,bg=black] #(whoami)@#H "
+set -g status-style "fg=#93a1a1,bg=#002b36"
 
-# Set format of items in window list.
-setw -g window-status-format " #I:#W#F "
-setw -g window-status-current-format " #I:#W#F "
+set -g status-left-length "100"
+set -g status-right-length "100"
 
-# Set alignment of windows list.
-set-option -g status-justify centre
+set -g status-left-style NONE
+set -g status-right-style NONE
 
-# Identify activity in non-current windows.
-set-window-option -g monitor-activity on
-set-option -g visual-activity on
+set -g status-left "#[fg=#002b36,bg=#2aa198,bold] #S #[fg=#2aa198,bg=#002b36,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#002b36,bg=#002b36,nobold,nounderscore,noitalics]#[fg=#93a1a1,bg=#002b36] #{prefix_highlight} #[fg=#073642,bg=#002b36,nobold,nounderscore,noitalics]#[fg=#93a1a1,bg=#073642] %Y-%m-%d  %I:%M %p #[fg=#2aa198,bg=#073642,nobold,nounderscore,noitalics]#[fg=#002b36,bg=#2aa198,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#002b36,bg=#002b36,nobold,nounderscore,noitalics]#[fg=#93a1a1,bg=#002b36] #{prefix_highlight} #[fg=#073642,bg=#002b36,nobold,nounderscore,noitalics]#[fg=#93a1a1,bg=#073642] %Y-%m-%d  %H:%M #[fg=#2aa198,bg=#073642,nobold,nounderscore,noitalics]#[fg=#002b36,bg=#2aa198,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#586e75,bg=#002b36"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#586e75,bg=#002b36"
+setw -g window-status-format "#[fg=#002b36,bg=#002b36,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#002b36,bg=#002b36,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#002b36,bg=#073642,nobold,nounderscore,noitalics]#[fg=#93a1a1,bg=#073642,bold] #I  #W #F #[fg=#073642,bg=#002b36,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#b58900]#[bg=#002b36]#[fg=#002b36]#[bg=#b58900]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/solarized-light.tmuxtheme
+++ b/themes/solarized-light.tmuxtheme
@@ -1,33 +1,38 @@
-# Tmux status line with solarized light colors.
-# Palette: http://ricky.thecampbells.info/solarized-quick-reference-posters/
+# Solarized Light
+# Palette: https://ethanschoonover.com/solarized/
+# base3=#fdf6e3 base2=#eee8d5 base1=#93a1a1 base01=#586e75 yellow=#b58900 cyan=#2aa198
 
-# Status bar colors.
-set-window-option -g status-style fg=brightyellow,bg=brightwhite,none
+set -g mode-style "fg=#2aa198,bg=#eee8d5"
 
-# Window list colors.
-set-window-option -g window-status-style fg=brightyellow,bg=brightwhite,none
-set-window-option -g window-status-current-style fg=white,bg=brightgreen,bold
-set-window-option -g window-status-activity-style fg=white,bg=brightcyan,none
+set -g message-style "fg=#586e75,bg=#eee8d5"
+set -g message-command-style "fg=#586e75,bg=#eee8d5"
 
-# Pane divider colors.
-set-option -g pane-border-style fg=brightyellow,bg=default
-set-option -g pane-active-border-style fg=yellow,bg=default
+set -g pane-border-style "fg=#eee8d5"
+set -g pane-active-border-style "fg=#2aa198"
 
-# Command-line messages colors.
-set-option message-style fg=brightyellow,bg=brightwhite
+set -g status "on"
+set -g status-justify "left"
 
-# Set left and right sections.
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=white,bg=brightgreen] #S "
-set-option -g status-right "#[fg=white,bg=brightgreen] #(whoami)@#H "
+set -g status-style "fg=#586e75,bg=#fdf6e3"
 
-# Set format of items in window list.
-setw -g window-status-format " #I:#W#F "
-setw -g window-status-current-format " #I:#W#F "
+set -g status-left-length "100"
+set -g status-right-length "100"
 
-# Set alignment of windows list.
-set-option -g status-justify centre
+set -g status-left-style NONE
+set -g status-right-style NONE
 
-# Identify activity in non-current windows.
-set-window-option -g monitor-activity on
-set-option -g visual-activity on
+set -g status-left "#[fg=#fdf6e3,bg=#2aa198,bold] #S #[fg=#2aa198,bg=#fdf6e3,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#fdf6e3,bg=#fdf6e3,nobold,nounderscore,noitalics]#[fg=#586e75,bg=#fdf6e3] #{prefix_highlight} #[fg=#eee8d5,bg=#fdf6e3,nobold,nounderscore,noitalics]#[fg=#586e75,bg=#eee8d5] %Y-%m-%d  %I:%M %p #[fg=#2aa198,bg=#eee8d5,nobold,nounderscore,noitalics]#[fg=#fdf6e3,bg=#2aa198,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#fdf6e3,bg=#fdf6e3,nobold,nounderscore,noitalics]#[fg=#586e75,bg=#fdf6e3] #{prefix_highlight} #[fg=#eee8d5,bg=#fdf6e3,nobold,nounderscore,noitalics]#[fg=#586e75,bg=#eee8d5] %Y-%m-%d  %H:%M #[fg=#2aa198,bg=#eee8d5,nobold,nounderscore,noitalics]#[fg=#fdf6e3,bg=#2aa198,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#93a1a1,bg=#fdf6e3"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#93a1a1,bg=#fdf6e3"
+setw -g window-status-format "#[fg=#fdf6e3,bg=#fdf6e3,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#fdf6e3,bg=#fdf6e3,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#fdf6e3,bg=#eee8d5,nobold,nounderscore,noitalics]#[fg=#586e75,bg=#eee8d5,bold] #I  #W #F #[fg=#eee8d5,bg=#fdf6e3,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#b58900]#[bg=#fdf6e3]#[fg=#fdf6e3]#[bg=#b58900]"
+set -g @prefix_highlight_output_suffix ""

--- a/themes/two-firewatch-light.tmuxtheme
+++ b/themes/two-firewatch-light.tmuxtheme
@@ -1,34 +1,38 @@
-# Tmux status line for the theme "Two Firewatch Dark"
-# See: https://github.com/rakr/vim-two-firewatch
-# See: https://github.com/rakr/iterm-two-firewatch
+# Two Firewatch Light
+# Inspired by: https://github.com/rakr/vim-two-firewatch
+# bg=#f9f5e3 panel=#ede8d4 orange=#e8783d brown=#a07040 text=#3d2b1f
 
-# Status bar colors.
-set-window-option -g status-style fg=default,bg=default
+set -g mode-style "fg=#e8783d,bg=#ede8d4"
 
-# Window list colors.
-set-window-option -g window-status-style fg=black,bg=blue,none
-set-window-option -g window-status-current-style fg=black,bold,bg=blue
-set-window-option -g window-status-activity-style fg=white,bg=brightcyan,none
+set -g message-style "fg=#3d2b1f,bg=#ede8d4"
+set -g message-command-style "fg=#3d2b1f,bg=#ede8d4"
 
-# Pane divider colors.
-set-option -g pane-border-style fg=yellow,bg=default
-set-option -g pane-active-border-style fg=red,bold,bg=default,bright
+set -g pane-border-style "fg=#ede8d4"
+set -g pane-active-border-style "fg=#e8783d"
 
-# Command-line messages colors.
-set-option message-style fg=black,bg=white
+set -g status "on"
+set -g status-justify "left"
 
-# Set left and right sections.
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=black,bg=green] #S "
-set-option -g status-right "#[fg=black,bg=green] #(whoami)@#H "
+set -g status-style "fg=#3d2b1f,bg=#f9f5e3"
 
-# Set format of items in window list.
-setw -g window-status-format " #I:#W#F "
-setw -g window-status-current-format " #I:#W#F "
+set -g status-left-length "100"
+set -g status-right-length "100"
 
-# Set alignment of windows list.
-set-option -g status-justify centre
+set -g status-left-style NONE
+set -g status-right-style NONE
 
-# Identify activity in non-current windows.
-set-window-option -g monitor-activity on
-set-option -g visual-activity on
+set -g status-left "#[fg=#f9f5e3,bg=#e8783d,bold] #S #[fg=#e8783d,bg=#f9f5e3,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=#f9f5e3,bg=#f9f5e3,nobold,nounderscore,noitalics]#[fg=#3d2b1f,bg=#f9f5e3] #{prefix_highlight} #[fg=#ede8d4,bg=#f9f5e3,nobold,nounderscore,noitalics]#[fg=#3d2b1f,bg=#ede8d4] %Y-%m-%d  %I:%M %p #[fg=#e8783d,bg=#ede8d4,nobold,nounderscore,noitalics]#[fg=#f9f5e3,bg=#e8783d,bold] #h "
+if-shell '[ "$(tmux show-option -gqv "clock-mode-style")" == "24" ]' {
+  set -g status-right "#[fg=#f9f5e3,bg=#f9f5e3,nobold,nounderscore,noitalics]#[fg=#3d2b1f,bg=#f9f5e3] #{prefix_highlight} #[fg=#ede8d4,bg=#f9f5e3,nobold,nounderscore,noitalics]#[fg=#3d2b1f,bg=#ede8d4] %Y-%m-%d  %H:%M #[fg=#e8783d,bg=#ede8d4,nobold,nounderscore,noitalics]#[fg=#f9f5e3,bg=#e8783d,bold] #h "
+}
+
+setw -g window-status-activity-style "underscore,fg=#a07040,bg=#f9f5e3"
+setw -g window-status-separator ""
+setw -g window-status-style "NONE,fg=#a07040,bg=#f9f5e3"
+setw -g window-status-format "#[fg=#f9f5e3,bg=#f9f5e3,nobold,nounderscore,noitalics]#[default] #I  #W #F #[fg=#f9f5e3,bg=#f9f5e3,nobold,nounderscore,noitalics]"
+setw -g window-status-current-format "#[fg=#f9f5e3,bg=#ede8d4,nobold,nounderscore,noitalics]#[fg=#e8783d,bg=#ede8d4,bold] #I  #W #F #[fg=#ede8d4,bg=#f9f5e3,nobold,nounderscore,noitalics]"
+
+# tmux-plugins/tmux-prefix-highlight support
+set -g @prefix_highlight_output_prefix "#[fg=#a07040]#[bg=#f9f5e3]#[fg=#f9f5e3]#[bg=#a07040]"
+set -g @prefix_highlight_output_suffix ""


### PR DESCRIPTION
## Summary

- **Add 4 Catppuccin themes** (`mocha`, `macchiato`, `frappe`, `latte`) using the official hex palette and the same powerline segment structure as the existing tokyonight themes
- **Standardize all 6 legacy themes** (`gruvbox-dark`, `gruvbox-light-hard`, `solarized-dark`, `solarized-light`, `ayu-light`, `two-firewatch-light`) from the old `colour`-number / named-color format to consistent `#rrggbb` hex + powerline separators with 12h/24h clock and `tmux-prefix-highlight` support
- **Fix `theme.tmux`**: option name was `@tmux-themes` but README documented `@tmux-statusline-theme` — aligned to the documented name; added error handling that shows a readable message and falls back to the default instead of a silent tmux error
- **Fix README**: wrong option name, wrong `two-firewatch-dark` filename (file is `two-firewatch-light`), missing `gruvbox-light-hard` from theme list, wrong manual install path (`themes.tmux` → `theme.tmux`); reorganized theme list into tables by palette family
- **Add `CONTRIBUTING.md`** with a full theme template, color role table, naming conventions, and a contributor checklist
- **Add `.editorconfig`** for consistent formatting across all file types

## Files changed

| File | Change |
|---|---|
| `themes/catppuccin-mocha.tmuxtheme` | new |
| `themes/catppuccin-macchiato.tmuxtheme` | new |
| `themes/catppuccin-frappe.tmuxtheme` | new |
| `themes/catppuccin-latte.tmuxtheme` | new |
| `themes/gruvbox-dark.tmuxtheme` | rewritten in powerline format |
| `themes/gruvbox-light-hard.tmuxtheme` | rewritten in powerline format |
| `themes/solarized-dark.tmuxtheme` | rewritten in powerline format |
| `themes/solarized-light.tmuxtheme` | rewritten in powerline format |
| `themes/ayu-light.tmuxtheme` | rewritten in powerline format |
| `themes/two-firewatch-light.tmuxtheme` | rewritten in powerline format |
| `theme.tmux` | fix option name, add error handling |
| `README.md` | fix bugs, add new themes, reorganize |
| `CONTRIBUTING.md` | new |
| `.editorconfig` | new |